### PR TITLE
print out the rectified calibration to the terminal

### DIFF
--- a/raw_image_pipeline/CMakeLists.txt
+++ b/raw_image_pipeline/CMakeLists.txt
@@ -107,6 +107,15 @@ install(DIRECTORY include/
   FILES_MATCHING PATTERN "*.hpp"
 )
 
+install(
+  DIRECTORY config 
+  DESTINATION share/${PROJECT_NAME}
+  FILES_MATCHING PATTERN "*.yaml"
+                 PATTERN "*.xml"
+                 PATTERN "*.launch"
+)
+
+
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(Eigen3 OpenCV raw_image_pipeline_white_balance yaml-cpp)

--- a/raw_image_pipeline/src/raw_image_pipeline/modules/undistortion.cpp
+++ b/raw_image_pipeline/src/raw_image_pipeline/modules/undistortion.cpp
@@ -150,7 +150,7 @@ cv::Mat UndistortionModule::getRectMask() const {
 // Helper methods
 //-----------------------------------------------------------------------------
 void UndistortionModule::loadCalibration(const std::string& file_path) {
-  std::cout << "Loading camera calibration from file " << file_path << std::endl;
+  std::cerr << "Loading camera calibration from file " << file_path << std::endl;
 
   // Check if file exists
   if (std::filesystem::exists(file_path)) {

--- a/raw_image_pipeline_ros/src/raw_image_pipeline_ros.cpp
+++ b/raw_image_pipeline_ros/src/raw_image_pipeline_ros.cpp
@@ -153,6 +153,18 @@ void RawImagePipelineRos::loadParams() {
   std::string calibration_file = readParameter("undistortion/calibration_file", std::string(""));
   raw_image_pipeline_->loadCameraCalibration(calibration_file);
 
+  cv::Mat rect_projection_matrix = raw_image_pipeline_->getRectProjectionMatrix();
+  cv::Mat rect_distortion_coeff = raw_image_pipeline_->getRectDistortionCoefficients();
+  std::cerr << "K: [";
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      if ((i == 0)&&(j==0)){ }else{ std::cerr << ", ";}
+      std::cerr << std::fixed << std::setprecision(10) << rect_projection_matrix.at<double>(i, j);
+    }
+  }
+  std::cerr << "]\n";
+  std::cerr << "D: [0.0, 0.0, 0.0, 0.0]\n";
+
   if (calibration_file.empty()) {
     int image_width = readParameter("undistortion/image_width", 640);
     int image_height = readParameter("undistortion/image_width", 480);


### PR DESCRIPTION
without needing any data to be fed in to produce camera_info topics

@HaedamOh / @mmattamala 
This will make it easier to complete the calibration procedure. The K and D matrix can be copied directly from the terminal
for use with rectified images

The output when running RIP will look like this:
```
[INFO] [1731434300.818628703] [raw_image_pipeline_ros_node_cam2]: color_enhancer/saturation_gain: 1.2
[INFO] [1731434300.818636321] [raw_image_pipeline_ros_node_cam2]: color_enhancer/value_gain: 1
[INFO] [1731434300.818643358] [raw_image_pipeline_ros_node_cam2]: undistortion/enabled: 1
[INFO] [1731434300.818650911] [raw_image_pipeline_ros_node_cam2]: undistortion/balance: 0.5
[INFO] [1731434300.824652472] [raw_image_pipeline_ros_node_cam2]: undistortion/fov_scale: 0.8
[INFO] [1731434300.830610541] [raw_image_pipeline_ros_node_cam2]: undistortion/calibration_file: /home/mfallon/ros2_ws/install/runtime_drs/share/runtime_drs/config/frn019/sensors_2024_10_29/calib_cam2.yaml
Loading camera calibration from file /home/mfallon/ros2_ws/install/runtime_drs/share/runtime_drs/config/frn019/sensors_2024_10_29/calib_cam2.yaml
K: [569.4055290697, 0.0000000000, 705.4328668331, 0.0000000000, 568.3496450807, 527.7287061451, 0.0000000000, 0.0000000000, 1.0000000000]
D: [0.0, 0.0, 0.0, 0.0]
[INFO] [1731434300.868523054] [raw_image_pipeline_ros_node_cam2]: [RawImagePipelineRos] Starting...
```